### PR TITLE
Fix model.md - fix ParameterList parameter

### DIFF
--- a/docs/examples/model.md
+++ b/docs/examples/model.md
@@ -216,9 +216,8 @@ Calendar iCalendar = new Calendar().withProdId("-//MyCalendarApp v1.0//EN")
 
 //Outlook uses a custom property to display HTML called the X-ALT-DESC property
 
-ParameterList htmlParameters = new ParameterList();
 XParameter fmtTypeParameter = new XParameter("FMTTYPE", "text/html");
-htmlParameters.add(fmtTypeParameter);
+htmlParameters.add(new ParameterList(List.of(fmtTypeParameter)));
 
 DateTime startTime, endTime;
 try {


### PR DESCRIPTION
ParameterList.add(x) does not add x to the ParameterList object directly, but will return a ParameterList with x in it

Without this change the .ics will be missing the FMTTYPE parameter and an email client such as MSFT Outlook will not show the HTML.